### PR TITLE
Fix subcategory heading size while keeping language headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,32 +5,28 @@ A curated list of amazing libraries and frameworks for building command-line int
 > **Legend**: 🆓 = Free/Open Source | 💰 = Paid/Commercial | 🔄 = Freemium (Free + Paid tiers)
 
 ## Python 🐍
-
-### CLI Frameworks & Argument Parsing
+#### CLI Frameworks & Argument Parsing
 - **[click](https://github.com/pallets/click)** 🆓 - Python package for creating beautiful command line interfaces (BSD-3-Clause)
 - **[typer](https://github.com/tiangolo/typer)** 🆓 - Modern Python library for building CLI applications based on type hints (MIT)
 - **[fire](https://github.com/google/python-fire)** 🆓 - Library for automatically generating CLIs from any Python object (Apache-2.0)
 - **[argparse](https://docs.python.org/3/library/argparse.html)** 🆓 - Built-in Python command-line parsing library (Python Software Foundation License)
 - **[docopt](https://github.com/docopt/docopt)** 🆓 - Command-line interface description language (MIT)
 - **[cement](https://github.com/datafolklabs/cement)** 🆓 - CLI Application Framework for Python (BSD-3-Clause)
-
-### Terminal UI & Formatting
+#### Terminal UI & Formatting
 - **[rich](https://github.com/Textualize/rich)** 🆓 - Rich text and beautiful formatting in the terminal (MIT)
 - **[textual](https://github.com/Textualize/textual)** 🆓 - Rapid Application Development framework for Python TUI applications (MIT)
 - **[colorama](https://github.com/tartley/colorama)** 🆓 - Cross-platform colored terminal text (BSD-3-Clause)
 - **[termcolor](https://github.com/termcolor/termcolor)** 🆓 - ANSI color formatting for output in terminal (MIT)
 - **[blessed](https://github.com/jquast/blessed)** 🆓 - Easy, practical library for making terminal apps (MIT)
 - **[prompt_toolkit](https://github.com/prompt-toolkit/python-prompt-toolkit)** 🆓 - Library for building powerful interactive command lines (BSD-3-Clause)
-
-### Progress & Interaction
+#### Progress & Interaction
 - **[tqdm](https://github.com/tqdm/tqdm)** 🆓 - Fast, extensible progress bar for Python and CLI (MPL-2.0/MIT)
 - **[alive-progress](https://github.com/rsalmei/alive-progress)** 🆓 - New kind of Progress Bar, with real-time throughput (MIT)
 - **[inquirer](https://github.com/magmax/python-inquirer)** 🆓 - Collection of common interactive command line user interfaces (MIT)
 - **[questionary](https://github.com/tmbo/questionary)** 🆓 - Python library for building pretty command line interfaces (MIT)
 
 ## Node.js / JavaScript 🟨
-
-### CLI Frameworks & Argument Parsing
+#### CLI Frameworks & Argument Parsing
 - **[caporal.js](https://github.com/mattallty/Caporal.js)** 🆓 - Full-featured framework for building command line applications (MIT)
 - **[clack](https://github.com/bombshell-dev/clack)** 🆓 - Minimal, high-level framework for interactive CLIs (MIT)
 - **[clipanion](https://github.com/arcanis/clipanion)** 🆓 - Type-safe CLI framework (MIT)
@@ -40,20 +36,16 @@ A curated list of amazing libraries and frameworks for building command-line int
 - **[oclif](https://github.com/oclif/oclif)** 🆓 - Open CLI Framework for building CLIs in Node.js (MIT)
 - **[sade](https://github.com/lukeed/sade)** 🆓 - Ridiculously small but powerful CLI framework (MIT)
 - **[yargs](https://github.com/yargs/yargs)** 🆓 - Yargs helps you build interactive command line tools (MIT)
-
-### Terminal UI & Formatting
+#### Terminal UI & Formatting
 - **[blessed](https://github.com/chjj/blessed)** 🆓 - High-level terminal interface library for Node.js (MIT)
 - **[blessed-contrib](https://github.com/yaronn/blessed-contrib)** 🆓 - Build terminal dashboards using ascii/graphics widgets (MIT)
 - **[boxen](https://github.com/sindresorhus/boxen)** 🆓 - Create boxes in the terminal (MIT)
 - **[chalk](https://github.com/chalk/chalk)** 🆓 - Terminal string styling done right (MIT)
 - **[cli-table3](https://github.com/cli-table/cli-table3)** 🆓 - Pretty unicode tables for the command line (MIT)
 - **[terminal-kit](https://github.com/cronvel/terminal-kit)** 🆓 - Terminal utilities for Node.js (MIT)
-- **[blessed](https://github.com/chjj/blessed)** 🆓 - High-level terminal interface library for Node.js (MIT)
-- **[blessed-contrib](https://github.com/yaronn/blessed-contrib)** 🆓 - Build terminal dashboards using ascii/graphics widgets (MIT)
 - **[ink](https://github.com/vadimdemedes/ink)** 🆓 - React for interactive command-line apps (MIT)
 - **[terminal-image](https://github.com/sindresorhus/terminal-image)** 🆓 - Display images in the terminal (MIT)
-
-### Progress & Interaction
+#### Progress & Interaction
 - **[cli-progress](https://github.com/npkgz/cli-progress)** 🆓 - Easy to use progress-bar for command-line/terminal applications (MIT)
 - **[enquirer](https://github.com/enquirer/enquirer)** 🆓 - Stylish, intuitive prompts for Node.js (MIT)
 - **[inquirer.js](https://github.com/SBoudrias/Inquirer.js)** 🆓 - Collection of common interactive command line user interfaces (MIT)
@@ -61,18 +53,14 @@ A curated list of amazing libraries and frameworks for building command-line int
 - **[ora](https://github.com/sindresorhus/ora)** 🆓 - Elegant terminal spinner (MIT)
 - **[progress](https://github.com/visionmedia/node-progress)** 🆓 - Flexible ascii progress bar for Node.js (MIT)
 - **[prompts](https://github.com/terkelg/prompts)** 🆓 - Lightweight, beautiful and user-friendly interactive prompts (MIT)
-- **[cli-progress](https://github.com/npkgz/cli-progress)** 🆓 - Easy to use progress-bar for command-line/terminal applications (MIT)
-- **[enquirer](https://github.com/enquirer/enquirer)** 🆓 - Stylish, intuitive prompts for Node.js (MIT)
 
 ## Rust 🦀
-
-### CLI Frameworks & Argument Parsing
+#### CLI Frameworks & Argument Parsing
 - **[clap](https://github.com/clap-rs/clap)** 🆓 - Command Line Argument Parser for Rust (MIT/Apache-2.0)
 - **[structopt](https://github.com/TeXitoi/structopt)** 🆓 - Parse command line arguments by defining a struct (MIT/Apache-2.0)
 - **[argh](https://github.com/google/argh)** 🆓 - Derive-based argument parser optimized for code size (BSD-3-Clause)
 - **[gumdrop](https://github.com/murarth/gumdrop)** 🆓 - Option parser with custom derive support (MIT/Apache-2.0)
-
-### Terminal UI & Formatting
+#### Terminal UI & Formatting
 - **[console](https://github.com/console-rs/console)** 🆓 - Terminal and console abstraction for Rust (MIT)
 - **[crossterm](https://github.com/crossterm-rs/crossterm)** 🆓 - Cross-platform terminal manipulation library (MIT)
 - **[termion](https://github.com/redox-os/termion)** 🆓 - Pure Rust, bindless library for low-level handling, manipulating and reading information about terminals (MIT)
@@ -80,133 +68,110 @@ A curated list of amazing libraries and frameworks for building command-line int
 - **[ratatui](https://github.com/ratatui-org/ratatui)** 🆓 - Library to build rich terminal user interfaces and dashboards (MIT)
 - **[colored](https://github.com/mackwic/colored)** 🆓 - Coloring terminal so simple you already know how to do it (MPL-2.0)
 - **[comfy-table](https://github.com/Nukesor/comfy-table)** 🆓 - Build beautiful terminal tables with automatic content wrapping (MIT)
-
-### Progress & Interaction
+#### Progress & Interaction
 - **[indicatif](https://github.com/console-rs/indicatif)** 🆓 - Rust library for indicating progress in command line applications (MIT)
 - **[dialoguer](https://github.com/console-rs/dialoguer)** 🆓 - Rust utility library for nice command line prompts (MIT)
 - **[inquire](https://github.com/mikaelmello/inquire)** 🆓 - Library for building interactive prompts on terminals (MIT)
 
 ## Go 🐹
-
-### CLI Frameworks & Argument Parsing
+#### CLI Frameworks & Argument Parsing
 - **[cobra](https://github.com/spf13/cobra)** 🆓 - Library for creating powerful modern CLI applications (Apache-2.0)
 - **[cli](https://github.com/urfave/cli)** 🆓 - Simple, fast, and fun package for building command line apps (MIT)
 - **[flag](https://pkg.go.dev/flag)** 🆓 - Built-in command-line flag parsing (BSD-3-Clause)
 - **[kingpin](https://github.com/alecthomas/kingpin)** 🆓 - Command line and flag parser supporting sub commands (MIT)
 - **[pflag](https://github.com/spf13/pflag)** 🆓 - Drop-in replacement for Go's flag package (BSD-3-Clause)
-
-### Configuration & Management
+#### Configuration & Management
 - **[viper](https://github.com/spf13/viper)** 🆓 - Go configuration with fangs (MIT)
 - **[envconfig](https://github.com/kelseyhightower/envconfig)** 🆓 - Library for managing configuration data from environment variables (MIT)
-
-### Terminal UI & Formatting
+#### Terminal UI & Formatting
 - **[bubbletea](https://github.com/charmbracelet/bubbletea)** 🆓 - Powerful little TUI framework (MIT)
 - **[lipgloss](https://github.com/charmbracelet/lipgloss)** 🆓 - Style definitions for nice terminal layouts (MIT)
 - **[termui](https://github.com/gizak/termui)** 🆓 - Golang terminal dashboard (MIT)
 - **[color](https://github.com/fatih/color)** 🆓 - Color package for Go (MIT)
 - **[aurora](https://github.com/logrusorgru/aurora)** 🆓 - Cross-platform ANSI color package (Unlicense)
 - **[tablewriter](https://github.com/olekukonko/tablewriter)** 🆓 - ASCII table in golang (MIT)
-
-### Progress & Interaction
+#### Progress & Interaction
 - **[survey](https://github.com/AlecAivazis/survey)** 🆓 - Library for building interactive and accessible prompts (MIT)
 - **[progressbar](https://github.com/schollz/progressbar)** 🆓 - Basic thread-safe progress bar (MIT)
 - **[mpb](https://github.com/vbauerster/mpb)** 🆓 - Multi progress bar for Go (Unlicense)
 
 ## Java ☕
-
-### CLI Frameworks & Argument Parsing
+#### CLI Frameworks & Argument Parsing
 - **[picocli](https://github.com/remkop/picocli)** 🆓 - Mighty tiny command line interface (Apache-2.0)
 - **[Apache Commons CLI](https://commons.apache.org/proper/commons-cli/)** 🆓 - Command Line arguments parser (Apache-2.0)
 - **[airline](https://github.com/airlift/airline)** 🆓 - Java library for parsing command line arguments (Apache-2.0)
 - **[args4j](https://github.com/kohsuke/args4j)** 🆓 - Java command line arguments parser (MIT)
 - **[JCommander](https://github.com/cbeust/jcommander)** 🆓 - Command line parsing framework for Java (Apache-2.0)
-
-### Terminal UI & Formatting
+#### Terminal UI & Formatting
 - **[JLine](https://github.com/jline/jline3)** 🆓 - Java library for handling console input (BSD-3-Clause)
 - **[Jansi](https://github.com/fusesource/jansi)** 🆓 - Java library for generating and interpreting ANSI escape sequences (Apache-2.0)
 - **[Lanterna](https://github.com/mabe02/lanterna)** 🆓 - Java library for creating text-based GUIs (LGPL-3.0)
-
-### Progress & Interaction
+#### Progress & Interaction
 - **[ProgressBar](https://github.com/ctongfei/progressbar)** 🆓 - Terminal-based progress bar for Java (MIT)
 
 ## Zig ⚡
-
-### CLI Frameworks & Argument Parsing
+#### CLI Frameworks & Argument Parsing
 - **[zig-clap](https://github.com/Hejsil/zig-clap)** 🆓 - Simple command line argument parsing library (MIT)
 - **[zig-args](https://github.com/MasterQ32/zig-args)** 🆓 - Simple-to-use argument parser (MIT)
 - **[yazap](https://github.com/PrajwalCH/yazap)** 🆓 - Yet Another Zig Argument Parser (MIT)
-
-### Terminal UI & Formatting
+#### Terminal UI & Formatting
 - **[vaxis](https://github.com/rockorager/libvaxis)** 🆓 - TUI library for Zig (MIT)
 
 ## Shell (Bash/Zsh/Fish) 🐚
-
-### Argument Parsing & Utilities
+#### Argument Parsing & Utilities
 - **[getopts](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/getopts.html)** 🆓 - Built-in POSIX shell utility for parsing options (POSIX)
 - **[shflags](https://github.com/kward/shflags)** 🆓 - Command-line flags module for Unix shell scripts (Apache-2.0)
 - **[argbash](https://github.com/matejak/argbash)** 🆓 - Bash argument parsing code generator (BSD-3-Clause)
-
-### Terminal UI & Formatting
+#### Terminal UI & Formatting
 - **[whiptail](https://linux.die.net/man/1/whiptail)** 🆓 - Display dialog boxes from shell scripts (LGPL)
 - **[dialog](https://invisible-island.net/dialog/)** 🆓 - Display dialog boxes from shell scripts (LGPL-2.1)
 - **[gum](https://github.com/charmbracelet/gum)** 🆓 - Tool for glamorous shell scripts (MIT)
-
-### Framework & Enhancement Tools
+#### Framework & Enhancement Tools
 - **[oh-my-zsh](https://github.com/ohmyzsh/ohmyzsh)** 🆓 - Framework for managing Zsh configuration (MIT)
 - **[oh-my-fish](https://github.com/oh-my-fish/oh-my-fish)** 🆓 - Framework for Fish shell (MIT)
 - **[bash-it](https://github.com/Bash-it/bash-it)** 🆓 - Community Bash framework (MIT)
 
 ## Lua 🌙
-
-### CLI Frameworks & Argument Parsing
+#### CLI Frameworks & Argument Parsing
 - **[argparse](https://github.com/luarocks/argparse)** 🆓 - Feature-rich command line parser for Lua (MIT)
 - **[lua-cliargs](https://github.com/lunarmodules/lua-cliargs)** 🆓 - Command-line argument parsing library (MIT)
 - **[penlight](https://github.com/lunarmodules/Penlight)** 🆓 - Lua libraries focusing on input data handling (MIT)
-
-### Terminal UI & Formatting
+#### Terminal UI & Formatting
 - **[lua-term](https://github.com/hoelzro/lua-term)** 🆓 - Terminal operations for Lua (MIT)
 - **[ansicolors](https://github.com/kikito/ansicolors.lua)** 🆓 - ANSI color library for Lua (MIT)
 
 ## C/C++ ⚙️
-
-### CLI Frameworks & Argument Parsing
+#### CLI Frameworks & Argument Parsing
 - **[CLI11](https://github.com/CLIUtils/CLI11)** 🆓 - Command line parser for C++11 (BSD-3-Clause)
 - **[cxxopts](https://github.com/jarro2783/cxxopts)** 🆓 - Lightweight C++ command line option parser (MIT)
 - **[argparse](https://github.com/p-ranav/argparse)** 🆓 - Argument Parser for Modern C++ (MIT)
 - **[TCLAP](https://tclap.sourceforge.net/)** 🆓 - Templated C++ Command Line Parser Library (MIT)
 - **[getopt](https://www.gnu.org/software/libc/manual/html_node/Getopt.html)** 🆓 - Standard C library function for parsing command-line options (LGPL)
 - **[argp](https://www.gnu.org/software/libc/manual/html_node/Argp.html)** 🆓 - Interface for parsing command-line arguments (LGPL)
-
-### Terminal UI & Formatting
+#### Terminal UI & Formatting
 - **[ncurses](https://invisible-island.net/ncurses/)** 🆓 - Library for text-based user interfaces (MIT-like)
 - **[termcolor](https://github.com/ikalnytskyi/termcolor)** 🆓 - Header-only C++ library for printing colored messages (BSD-3-Clause)
 - **[ftxui](https://github.com/ArthurSonzogni/FTXUI)** 🆓 - C++ Functional Terminal User Interface (MIT)
-
-### Progress & Interaction
+#### Progress & Interaction
 - **[indicators](https://github.com/p-ranav/indicators)** 🆓 - Activity Indicators for Modern C++ (MIT)
 
 ## Additional Languages
-
 ### Ruby 💎
 - **[thor](https://github.com/rails/thor)** 🆓 - Toolkit for building powerful command-line interfaces (MIT)
 - **[gli](https://github.com/davetron5000/gli)** 🆓 - Git-like interface command line library (Apache-2.0)
 - **[optparse](https://ruby-doc.org/stdlib/libdoc/optparse/rdoc/OptionParser.html)** 🆓 - Built-in command-line option analysis (Ruby License)
 - **[tty](https://github.com/piotrmurach/tty)** 🆓 - Toolkit for developing sleek command line apps (MIT)
-
 ### PHP 🐘
 - **[symfony/console](https://github.com/symfony/console)** 🆓 - Eases the creation of beautiful and testable command line interfaces (MIT)
 - **[minicli](https://github.com/minicli/minicli)** 🆓 - Minimalist framework for command-line applications (MIT)
 - **[silly](https://github.com/mnapoli/silly)** 🆓 - CLI micro-framework based on Symfony Console (MIT)
 - **[CLImate](https://github.com/thephpleague/climate)** 🆓 - PHP's best friend for the terminal (MIT)
-
 ### Swift 🦉
 - **[swift-argument-parser](https://github.com/apple/swift-argument-parser)** 🆓 - Straightforward, type-safe argument parsing for Swift (Apache-2.0)
 - **[Commander](https://github.com/kylef/Commander)** 🆓 - Compose beautiful command line interfaces in Swift (BSD-2-Clause)
-
 ### Kotlin 🎯
 - **[clikt](https://github.com/ajalt/clikt)** 🆓 - Multiplatform command line interface parsing for Kotlin (Apache-2.0)
 - **[kotlinx-cli](https://github.com/Kotlin/kotlinx-cli)** 🆓 - Pure Kotlin implementation of a generic command-line parser (Apache-2.0)
-
 ### .NET/C# 🔷
 - **[CommandLineParser](https://github.com/commandlineparser/commandline)** 🆓 - Terse command line parser for C# (MIT)
 - **[System.CommandLine](https://github.com/dotnet/command-line-api)** 🆓 - Command line parsing, invocation, and rendering of terminal output (MIT)


### PR DESCRIPTION
## Summary
- keep Ruby, PHP, Swift, Kotlin, and .NET/C# headers at `###`
- avoid duplicate Node.js packages and tighten subcategory spacing

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_68482714ec90833297df4b5c0cd3c5a2